### PR TITLE
Add P6394 to the list of properties

### DIFF
--- a/VIAFbotWD.py
+++ b/VIAFbotWD.py
@@ -62,7 +62,8 @@ propertyMap = {'TYP': 'P107',
              'SUDOC':'P269', 
              #'KID':, 
              #'WORLDCATID':
-             'ISNI': 'P213',}
+             'ISNI': 'P213',
+             'ERRR': 'P6394',}
          
 sourceMap = {'imported from':'P143',
              'en':'Q328',


### PR DESCRIPTION
Hi! We just got https://www.wikidata.org/wiki/Property:P6394 added, which is currently only sourceable from VIAF. If I understand correctly, one of the tasks from this bot is to add IDs from VIAF to Wikidata - in that case, it'd be great if we could do that for P6394 too :) 

If something else needs to be done than just adding it to this list, I'm happy to look into it too - I could run my own bot for this, but given a VIAFBot already exists, it feels more reasonable to do it this way if it's ok with you!